### PR TITLE
Refactor Printer trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 - Experimental Sixel support
+- Remove `resize` Config option
+- Change `Printer` trait function signatures
+- Improve test suite
+- Major refactor of `BlockPrinter`
 
 ## 0.3.1
 - Make `ViuResult` public

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,8 +2,6 @@ use crate::utils;
 
 /// Configuration struct to customize printing behaviour.
 pub struct Config {
-    /// [resize](crate::resize) the image before printing. Defaults to true.
-    pub resize: bool,
     /// Enable true transparency instead of checkerboard background.
     /// Available only for the block printer. Defaults to false.
     pub transparent: bool,
@@ -36,7 +34,6 @@ pub struct Config {
 impl std::default::Default for Config {
     fn default() -> Self {
         Self {
-            resize: true,
             transparent: false,
             absolute_offset: true,
             x: 0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@
 
 use crossterm::execute;
 use image::DynamicImage;
-use printer::Printer;
+use printer::{Printer, PrinterType};
 
 mod config;
 mod error;
@@ -72,9 +72,7 @@ pub fn print(img: &DynamicImage, config: &Config) -> ViuResult<(u32, u32)> {
         execute!(&mut stdout, crossterm::cursor::SavePosition)?;
     }
 
-    let printer = choose_printer(config);
-
-    let (w, h) = printer.print(img, config)?;
+    let (w, h) = choose_printer(config).print(&mut stdout, img, config)?;
 
     if config.restore_cursor {
         execute!(&mut stdout, crossterm::cursor::RestorePosition)?;
@@ -103,9 +101,7 @@ pub fn print_from_file(filename: &str, config: &Config) -> ViuResult<(u32, u32)>
         execute!(&mut stdout, crossterm::cursor::SavePosition)?;
     }
 
-    let printer = choose_printer(config);
-
-    let (w, h) = printer.print_from_file(filename, config)?;
+    let (w, h) = choose_printer(config).print_from_file(&mut stdout, filename, config)?;
 
     if config.restore_cursor {
         execute!(&mut stdout, crossterm::cursor::RestorePosition)?;
@@ -115,17 +111,17 @@ pub fn print_from_file(filename: &str, config: &Config) -> ViuResult<(u32, u32)>
 }
 
 // Choose the appropriate printer to use based on user config and availability
-fn choose_printer(config: &Config) -> Box<dyn Printer> {
+fn choose_printer(config: &Config) -> PrinterType {
     #[cfg(feature = "sixel")]
     if config.use_sixel && is_sixel_supported() {
-        return Box::new(printer::SixelPrinter {});
+        return printer::PrinterType::Sixel;
     }
 
     if config.use_iterm && is_iterm_supported() {
-        Box::new(printer::iTermPrinter {})
+        printer::PrinterType::iTerm
     } else if config.use_kitty && get_kitty_support() != KittySupport::None {
-        Box::new(printer::KittyPrinter {})
+        printer::PrinterType::Kitty
     } else {
-        Box::new(printer::BlockPrinter {})
+        printer::PrinterType::Block
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,10 @@
 //! print_from_file("img.jpg", &conf).expect("Image printing failed.");
 //! ```
 
-use crossterm::execute;
+use crossterm::{
+    cursor::{RestorePosition, SavePosition},
+    execute,
+};
 use image::DynamicImage;
 use printer::{Printer, PrinterType};
 
@@ -69,13 +72,13 @@ pub use printer::is_sixel_supported;
 pub fn print(img: &DynamicImage, config: &Config) -> ViuResult<(u32, u32)> {
     let mut stdout = std::io::stdout();
     if config.restore_cursor {
-        execute!(&mut stdout, crossterm::cursor::SavePosition)?;
+        execute!(&mut stdout, SavePosition)?;
     }
 
     let (w, h) = choose_printer(config).print(&mut stdout, img, config)?;
 
     if config.restore_cursor {
-        execute!(&mut stdout, crossterm::cursor::RestorePosition)?;
+        execute!(&mut stdout, RestorePosition)?;
     };
 
     Ok((w, h))
@@ -98,13 +101,13 @@ pub fn print(img: &DynamicImage, config: &Config) -> ViuResult<(u32, u32)> {
 pub fn print_from_file(filename: &str, config: &Config) -> ViuResult<(u32, u32)> {
     let mut stdout = std::io::stdout();
     if config.restore_cursor {
-        execute!(&mut stdout, crossterm::cursor::SavePosition)?;
+        execute!(&mut stdout, SavePosition)?;
     }
 
     let (w, h) = choose_printer(config).print_from_file(&mut stdout, filename, config)?;
 
     if config.restore_cursor {
-        execute!(&mut stdout, crossterm::cursor::RestorePosition)?;
+        execute!(&mut stdout, RestorePosition)?;
     };
 
     Ok((w, h))
@@ -114,14 +117,14 @@ pub fn print_from_file(filename: &str, config: &Config) -> ViuResult<(u32, u32)>
 fn choose_printer(config: &Config) -> PrinterType {
     #[cfg(feature = "sixel")]
     if config.use_sixel && is_sixel_supported() {
-        return printer::PrinterType::Sixel;
+        return PrinterType::Sixel;
     }
 
     if config.use_iterm && is_iterm_supported() {
-        printer::PrinterType::iTerm
+        PrinterType::iTerm
     } else if config.use_kitty && get_kitty_support() != KittySupport::None {
-        printer::PrinterType::Kitty
+        PrinterType::Kitty
     } else {
-        printer::PrinterType::Block
+        PrinterType::Block
     }
 }

--- a/src/printer/block.rs
+++ b/src/printer/block.rs
@@ -183,57 +183,57 @@ mod tests {
     use termcolor::{Ansi, Color};
 
     #[test]
-    fn test_block_printer_small() {
-        let img = DynamicImage::ImageRgba8(image::RgbaImage::new(20, 7));
+    fn test_block_printer_e2e() {
+        let img = DynamicImage::ImageRgba8(image::RgbaImage::new(5, 4));
+        let mut buf = Ansi::new(vec![]);
 
-        let config = Config {
-            width: Some(40),
-            height: None,
-            absolute_offset: false,
-            transparent: true,
-            ..Default::default()
-        };
-        let mut vec = Vec::new();
-        let (w, h) = BlockPrinter {}.print(&mut vec, &img, &config).unwrap();
+        let config = Config::default();
 
-        assert_eq!(w, 20);
-        assert_eq!(h, 4);
+        let (w, h) = print_to_writecolor(&mut buf, &img, &config).unwrap();
+        assert_eq!((w, h), (5, 2));
+
+        assert_eq!(
+            std::str::from_utf8(buf.get_ref()).unwrap(),
+            "\x1b[1;1H\x1b[0m\x1b[38;2;153;153;153m\x1b[48;2;102;102;102m▄\x1b[0m\x1b[38;2;102;102;102m\x1b[48;2;153;153;153m▄\x1b[0m\x1b[38;2;153;153;153m\x1b[48;2;102;102;102m▄\x1b[0m\x1b[38;2;102;102;102m\x1b[48;2;153;153;153m▄\x1b[0m\x1b[38;2;153;153;153m\x1b[48;2;102;102;102m▄\x1b[0m\n\x1b[0m\x1b[38;2;153;153;153m\x1b[48;2;102;102;102m▄\x1b[0m\x1b[38;2;102;102;102m\x1b[48;2;153;153;153m▄\x1b[0m\x1b[38;2;153;153;153m\x1b[48;2;102;102;102m▄\x1b[0m\x1b[38;2;102;102;102m\x1b[48;2;153;153;153m▄\x1b[0m\x1b[38;2;153;153;153m\x1b[48;2;102;102;102m▄\x1b[0m\n"
+        );
     }
 
     #[test]
-    fn test_block_printer_large() {
-        let img = DynamicImage::ImageRgba8(image::RgbaImage::new(2000, 999));
+    fn test_block_printer_e2e_transparent() {
+        let img = DynamicImage::ImageRgba8(image::RgbaImage::new(5, 4));
+        let mut buf = Ansi::new(vec![]);
 
         let config = Config {
-            width: Some(160),
-            height: None,
-            absolute_offset: false,
             transparent: true,
             ..Default::default()
         };
-        let mut vec = Vec::new();
-        let (w, h) = BlockPrinter {}.print(&mut vec, &img, &config).unwrap();
 
-        assert_eq!(w, 160);
-        assert_eq!(h, 39);
+        let (w, h) = print_to_writecolor(&mut buf, &img, &config).unwrap();
+        assert_eq!((w, h), (5, 2));
+
+        assert_eq!(
+            std::str::from_utf8(buf.get_ref()).unwrap(),
+            "\x1b[1;1H\x1b[1C\x1b[1C\x1b[1C\x1b[1C\x1b[1C\x1b[0m\n\x1b[1C\x1b[1C\x1b[1C\x1b[1C\x1b[1C\x1b[0m\n"
+        );
     }
 
     #[test]
-    fn test_block_printer_tall() {
-        let img = DynamicImage::ImageRgba8(image::RgbaImage::new(799, 3001));
+    fn test_block_printer_e2e_odd_height() {
+        let img = DynamicImage::ImageRgba8(image::RgbaImage::new(4, 3));
+        let mut buf = Ansi::new(vec![]);
 
         let config = Config {
-            width: Some(80),
-            height: None,
+            width: Some(20),
             absolute_offset: false,
-            transparent: true,
             ..Default::default()
         };
-        let mut vec = Vec::new();
-        let (w, h) = BlockPrinter {}.print(&mut vec, &img, &config).unwrap();
+        let (w, h) = print_to_writecolor(&mut buf, &img, &config).unwrap();
+        assert_eq!((w, h), (4, 2));
 
-        assert_eq!(w, 80);
-        assert_eq!(h, 150);
+        assert_eq!(
+            std::str::from_utf8(buf.get_ref()).unwrap(),
+            "\x1b[0m\x1b[38;2;153;153;153m\x1b[48;2;102;102;102m▄\x1b[0m\x1b[38;2;102;102;102m\x1b[48;2;153;153;153m▄\x1b[0m\x1b[38;2;153;153;153m\x1b[48;2;102;102;102m▄\x1b[0m\x1b[38;2;102;102;102m\x1b[48;2;153;153;153m▄\x1b[0m\n\x1b[0m\x1b[38;2;102;102;102m▀\x1b[0m\x1b[38;2;153;153;153m▀\x1b[0m\x1b[38;2;102;102;102m▀\x1b[0m\x1b[38;2;153;153;153m▀\x1b[0m\n"
+        );
     }
 
     #[test]

--- a/src/printer/block.rs
+++ b/src/printer/block.rs
@@ -148,7 +148,6 @@ fn write_colored_character(
     Ok(())
 }
 
-#[inline]
 fn is_pixel_transparent(pixel: (u32, u32, &Rgba<u8>)) -> bool {
     pixel.2[3] == 0
 }

--- a/src/printer/block.rs
+++ b/src/printer/block.rs
@@ -16,10 +16,15 @@ const LOWER_HALF_BLOCK: &str = "\u{2584}";
 const CHECKERBOARD_BACKGROUND_LIGHT: (u8, u8, u8) = (153, 153, 153);
 const CHECKERBOARD_BACKGROUND_DARK: (u8, u8, u8) = (102, 102, 102);
 
-pub struct BlockPrinter {}
+pub struct BlockPrinter;
 
 impl Printer for BlockPrinter {
-    fn print(&self, img: &DynamicImage, config: &Config) -> ViuResult<(u32, u32)> {
+    fn print(
+        &self,
+        stdout: &mut impl Write,
+        img: &DynamicImage,
+        config: &Config,
+    ) -> ViuResult<(u32, u32)> {
         // there are two types of buffers in this function:
         // - stdout: Buffer, which is from termcolor crate. Used to buffer all writing
         //   required to print a single image or frame. Flushed on every line
@@ -276,7 +281,8 @@ mod tests {
             transparent: true,
             ..Default::default()
         };
-        let (w, h) = BlockPrinter {}.print(&img, &config).unwrap();
+        let mut vec = Vec::new();
+        let (w, h) = BlockPrinter {}.print(&mut vec, &img, &config).unwrap();
 
         assert_eq!(w, 20);
         assert_eq!(h, 3);
@@ -294,7 +300,8 @@ mod tests {
             transparent: true,
             ..Default::default()
         };
-        let (w, h) = BlockPrinter {}.print(&img, &config).unwrap();
+        let mut vec = Vec::new();
+        let (w, h) = BlockPrinter {}.print(&mut vec, &img, &config).unwrap();
 
         assert_eq!(w, 160);
         assert_eq!(h, 40);

--- a/src/printer/block.rs
+++ b/src/printer/block.rs
@@ -32,14 +32,7 @@ impl Printer for BlockPrinter {
         adjust_offset(&mut stream, &Config { x: 0, ..*config })?;
 
         // resize the image so that it fits in the constraints, if any
-        let resized_img;
-
-        let img = if config.resize {
-            resized_img = super::resize(&img, config.width, config.height);
-            &resized_img
-        } else {
-            img
-        };
+        let img = super::resize(&img, config.width, config.height);
         let (width, height) = img.dimensions();
 
         let mut row_color_buffer: Vec<ColorSpec> = vec![ColorSpec::new(); width as usize];

--- a/src/printer/block.rs
+++ b/src/printer/block.rs
@@ -5,7 +5,7 @@ use crate::Config;
 use ansi_colours::ansi256_from_rgb;
 use image::{DynamicImage, GenericImageView, Rgba};
 use std::io::Write;
-use termcolor::{Buffer, BufferWriter, Color, ColorChoice, ColorSpec, WriteColor};
+use termcolor::{BufferedStandardStream, Color, ColorChoice, ColorSpec, WriteColor};
 
 use crossterm::cursor::{MoveRight, MoveTo, MoveToPreviousLine};
 use crossterm::execute;
@@ -21,7 +21,8 @@ pub struct BlockPrinter;
 impl Printer for BlockPrinter {
     fn print(
         &self,
-        stdout: &mut impl Write,
+        // TODO: The provided object is not used because termcolor needs an implementation of the WriteColor trait
+        _stdout: &mut impl Write,
         img: &DynamicImage,
         config: &Config,
     ) -> ViuResult<(u32, u32)> {
@@ -31,14 +32,13 @@ impl Printer for BlockPrinter {
         // - row_buffer: Vec<ColorSpec>, which stores back- and foreground colors for a
         //   row of terminal cells. When flushed, its output goes into out_buffer.
         // They are both flushed on every terminal line (i.e 2 pixel rows)
-        let stdout = BufferWriter::stdout(ColorChoice::Always);
-        let mut out_buffer = stdout.buffer();
+        let mut stream = BufferedStandardStream::stdout(ColorChoice::Always);
 
         // adjust y offset
         if config.absolute_offset {
             if config.y >= 0 {
                 // If absolute_offset, move to (0,y).
-                execute!(out_buffer, MoveTo(0, config.y as u16))?;
+                execute!(stream, MoveTo(0, config.y as u16))?;
             } else {
                 //Negative values do not make sense.
                 return Err(ViuError::InvalidConfiguration(
@@ -47,13 +47,13 @@ impl Printer for BlockPrinter {
             }
         } else if config.y < 0 {
             // MoveUp if negative
-            execute!(out_buffer, MoveToPreviousLine(-config.y as u16))?;
+            execute!(stream, MoveToPreviousLine(-config.y as u16))?;
         } else {
             // Move down y lines
             for _ in 0..config.y {
                 // writeln! is used instead of MoveDown to force scrolldown
                 // observed when config.y > 0 and cursor is on the last terminal line
-                writeln!(out_buffer)?;
+                writeln!(stream)?;
             }
         }
 
@@ -65,171 +65,108 @@ impl Printer for BlockPrinter {
         } else {
             img
         };
+        let (width, height) = img.dimensions();
 
-        let (width, _) = img.dimensions();
+        let mut row_color_buffer: Vec<ColorSpec> = vec![ColorSpec::new(); width as usize];
+        let img_buffer = img.to_rgba8(); //TODO: Can conversion be avoided?
 
-        // TODO: position information is contained in the pixel
-        let mut curr_col_px = 0;
-        let mut curr_row_px = 0;
+        for (curr_row, img_row) in img_buffer.enumerate_rows() {
+            let is_even_row = curr_row % 2 == 0;
+            let is_last_row = curr_row == height;
 
-        let mut row_buffer: Vec<ColorSpec> = Vec::with_capacity(width as usize);
-
-        // row_buffer building mode. At first the top colors are calculated and then the bottom
-        // Once the bottom row is ready, row_buffer is flushed
-        let mut mode = Mode::Top;
-
-        // iterate pixels and fill row_buffer
-        for pixel in img.pixels() {
-            // if the alpha of the pixel is 0, print a predefined pixel based on the position in order
-            // to mimic the checherboard background. If the transparent option was given, move right instead
-            let color = if is_pixel_transparent(pixel) {
-                if config.transparent {
-                    None
-                } else {
-                    Some(get_transparency_color(
-                        curr_row_px,
-                        curr_col_px,
-                        config.truecolor,
-                    ))
-                }
-            } else {
-                Some(get_color_from_pixel(pixel, config.truecolor))
-            };
-
-            if mode == Mode::Top {
-                // add a new ColorSpec to row_buffer
-                let mut c = ColorSpec::new();
-                c.set_bg(color);
-                row_buffer.push(c);
-            } else {
-                // upgrade an already existing ColorSpec
-                let colorspec_to_upg = &mut row_buffer[curr_col_px as usize];
-                colorspec_to_upg.set_fg(color);
+            // move right if x offset is specified
+            if config.x > 0 {
+                execute!(stream, MoveRight(config.x))?;
             }
 
-            curr_col_px += 1;
-            // if the buffer is full start adding the second row of pixels
-            if row_buffer.len() == width as usize {
-                if mode == Mode::Top {
-                    mode = Mode::Bottom;
-                    curr_col_px = 0;
-                    curr_row_px += 1;
-                }
-                // only if the second row is completed, flush the buffer and start again
-                else if curr_col_px == width {
-                    curr_col_px = 0;
-                    curr_row_px += 1;
-
-                    // move right if x offset is specified
-                    if config.x > 0 {
-                        execute!(out_buffer, MoveRight(config.x))?;
+            for pixel in img_row {
+                // choose the half block's color
+                let color = if is_pixel_transparent(pixel) {
+                    if config.transparent {
+                        None
+                    } else {
+                        Some(get_transparency_color(curr_row, pixel.0, config.truecolor))
                     }
-
-                    // flush the row_buffer into out_buffer
-                    fill_out_buffer(&mut row_buffer, &mut out_buffer, false)?;
-
-                    // write the line to stdout
-                    print_buffer(&stdout, &mut out_buffer)?;
-
-                    mode = Mode::Top;
                 } else {
-                    // in the middle of the second row, more iterations are required
+                    Some(get_color_from_pixel(pixel, config.truecolor))
+                };
+
+                // Even rows modify the background, odd rows the foreground
+                let colorspec = &mut row_color_buffer[pixel.0 as usize];
+                if is_even_row {
+                    colorspec.set_bg(color);
+                } else {
+                    colorspec.set_fg(color);
+                    write_colored_character(&mut stream, colorspec, is_last_row)?;
                 }
             }
-        }
 
-        // buffer will be flushed if the image has an odd height
-        if !row_buffer.is_empty() {
-            fill_out_buffer(&mut row_buffer, &mut out_buffer, true)?;
+            if !is_even_row {
+                stream.reset()?;
+                writeln!(&mut stream)?;
+            }
         }
-
-        // do a final write to stdout to print last row if length is odd, and reset cursor position
-        print_buffer(&stdout, &mut out_buffer)?;
 
         // TODO: might be +1/2 ?
-        Ok((width, curr_row_px / 2))
+        Ok((width, height / 2))
     }
 }
 
-// Send out_buffer to stdout. Empties it when it's done
-fn print_buffer(stdout: &BufferWriter, out_buffer: &mut Buffer) -> ViuResult {
-    match stdout.print(out_buffer) {
-        Ok(_) => {
-            out_buffer.clear();
-            Ok(())
-        }
-        Err(e) => match e.kind() {
-            // Ignore broken pipe errors. They arise when piping output to `head`, for example,
-            // and panic is not desired.
-            std::io::ErrorKind::BrokenPipe => Ok(()),
-            _ => Err(ViuError::IO(e)),
-        },
-    }
-}
-
-// Translates the row_buffer, containing colors, into the out_buffer which will be flushed to the terminal
-fn fill_out_buffer(
-    row_buffer: &mut Vec<ColorSpec>,
-    out_buffer: &mut Buffer,
+fn write_colored_character(
+    stdout: &mut impl WriteColor,
+    c: &ColorSpec,
     is_last_row: bool,
 ) -> ViuResult {
-    let mut out_color;
-    let mut out_char;
+    let out_color;
+    let out_char;
     let mut new_color;
 
-    for c in row_buffer.iter() {
-        // If a flush is needed it means that only one row with UPPER_HALF_BLOCK must be printed
-        // because it is the last row, hence it contains only 1 pixel
-        if is_last_row {
-            new_color = ColorSpec::new();
-            if let Some(bg) = c.bg() {
-                new_color.set_fg(Some(*bg));
-                out_char = UPPER_HALF_BLOCK;
-            } else {
-                execute!(out_buffer, MoveRight(1))?;
-                continue;
-            }
-            out_color = &new_color;
+    if is_last_row {
+        new_color = ColorSpec::new();
+        if let Some(bg) = c.bg() {
+            new_color.set_fg(Some(*bg));
+            out_char = UPPER_HALF_BLOCK;
         } else {
-            match (c.fg(), c.bg()) {
-                (None, None) => {
-                    // completely transparent
-                    execute!(out_buffer, MoveRight(1))?;
-                    continue;
-                }
-                (Some(bottom), None) => {
-                    // only top transparent
-                    new_color = ColorSpec::new();
-                    new_color.set_fg(Some(*bottom));
-                    out_color = &new_color;
-                    out_char = LOWER_HALF_BLOCK;
-                }
-                (None, Some(top)) => {
-                    // only bottom transparent
-                    new_color = ColorSpec::new();
-                    new_color.set_fg(Some(*top));
-                    out_color = &new_color;
-                    out_char = UPPER_HALF_BLOCK;
-                }
-                (Some(_top), Some(_bottom)) => {
-                    // both parts have a color
-                    out_color = c;
-                    out_char = LOWER_HALF_BLOCK;
-                }
+            execute!(stdout, MoveRight(1))?;
+            return Ok(());
+        }
+        out_color = &new_color;
+    } else {
+        match (c.fg(), c.bg()) {
+            (None, None) => {
+                // completely transparent
+                execute!(stdout, MoveRight(1))?;
+                return Ok(());
+            }
+            (Some(bottom), None) => {
+                // only top transparent
+                new_color = ColorSpec::new();
+                new_color.set_fg(Some(*bottom));
+                out_color = &new_color;
+                out_char = LOWER_HALF_BLOCK;
+            }
+            (None, Some(top)) => {
+                // only bottom transparent
+                new_color = ColorSpec::new();
+                new_color.set_fg(Some(*top));
+                out_color = &new_color;
+                out_char = UPPER_HALF_BLOCK;
+            }
+            (Some(_top), Some(_bottom)) => {
+                // both parts have a color
+                out_color = c;
+                out_char = LOWER_HALF_BLOCK;
             }
         }
-        out_buffer.set_color(out_color)?;
-        write!(out_buffer, "{}", out_char)?;
     }
-
-    out_buffer.reset()?;
-    writeln!(out_buffer)?;
-    row_buffer.clear();
+    stdout.set_color(out_color)?;
+    write!(stdout, "{}", out_char)?;
 
     Ok(())
 }
 
-fn is_pixel_transparent(pixel: (u32, u32, Rgba<u8>)) -> bool {
+fn is_pixel_transparent(pixel: (u32, u32, &Rgba<u8>)) -> bool {
+    //TODO: pixel.2[3] ?
     let (_x, _y, data) = pixel;
     data[3] == 0
 }
@@ -248,7 +185,7 @@ fn get_transparency_color(row: u32, col: u32, truecolor: bool) -> Color {
     }
 }
 
-fn get_color_from_pixel(pixel: (u32, u32, Rgba<u8>), truecolor: bool) -> Color {
+fn get_color_from_pixel(pixel: (u32, u32, &Rgba<u8>), truecolor: bool) -> Color {
     let (_x, _y, data) = pixel;
     let rgb = (data[0], data[1], data[2]);
     if truecolor {
@@ -256,14 +193,6 @@ fn get_color_from_pixel(pixel: (u32, u32, Rgba<u8>), truecolor: bool) -> Color {
     } else {
         Color::Ansi256(ansi256_from_rgb(rgb))
     }
-}
-
-// enum used to keep track where the current line of pixels processed should be displayed - as
-// background or foreground color
-#[derive(PartialEq)]
-enum Mode {
-    Top,
-    Bottom,
 }
 
 #[cfg(test)]
@@ -288,7 +217,6 @@ mod tests {
         assert_eq!(h, 3);
     }
 
-    // TODO: failing on Windows. Why?
     #[test]
     fn test_block_printer_large() {
         let img = DynamicImage::ImageRgba8(image::RgbaImage::new(2000, 1000));

--- a/src/printer/block.rs
+++ b/src/printer/block.rs
@@ -90,7 +90,7 @@ impl Printer for BlockPrinter {
         writeln!(&mut stream)?;
         stream.flush()?;
 
-        Ok((width, height / 2))
+        Ok((width, height / 2 + height % 2))
     }
 }
 

--- a/src/printer/block.rs
+++ b/src/printer/block.rs
@@ -103,6 +103,7 @@ fn write_colored_character(
     let out_char;
     let mut new_color;
 
+    // On the last row use upper blocks and leave the bottom half empty (transparent)
     if is_last_row {
         new_color = ColorSpec::new();
         if let Some(bg) = c.bg() {
@@ -182,7 +183,7 @@ mod tests {
 
     #[test]
     fn test_block_printer_small() {
-        let img = DynamicImage::ImageRgba8(image::RgbaImage::new(20, 6));
+        let img = DynamicImage::ImageRgba8(image::RgbaImage::new(20, 7));
 
         let config = Config {
             width: Some(40),
@@ -195,12 +196,12 @@ mod tests {
         let (w, h) = BlockPrinter {}.print(&mut vec, &img, &config).unwrap();
 
         assert_eq!(w, 20);
-        assert_eq!(h, 3);
+        assert_eq!(h, 4);
     }
 
     #[test]
     fn test_block_printer_large() {
-        let img = DynamicImage::ImageRgba8(image::RgbaImage::new(2000, 1000));
+        let img = DynamicImage::ImageRgba8(image::RgbaImage::new(2000, 999));
 
         let config = Config {
             width: Some(160),
@@ -213,6 +214,24 @@ mod tests {
         let (w, h) = BlockPrinter {}.print(&mut vec, &img, &config).unwrap();
 
         assert_eq!(w, 160);
-        assert_eq!(h, 40);
+        assert_eq!(h, 39);
+    }
+
+    #[test]
+    fn test_block_printer_tall() {
+        let img = DynamicImage::ImageRgba8(image::RgbaImage::new(799, 3001));
+
+        let config = Config {
+            width: Some(80),
+            height: None,
+            absolute_offset: false,
+            transparent: true,
+            ..Default::default()
+        };
+        let mut vec = Vec::new();
+        let (w, h) = BlockPrinter {}.print(&mut vec, &img, &config).unwrap();
+
+        assert_eq!(w, 80);
+        assert_eq!(h, 150);
     }
 }

--- a/src/printer/block.rs
+++ b/src/printer/block.rs
@@ -182,19 +182,24 @@ mod tests {
     use super::*;
     use termcolor::{Ansi, Color};
 
+    // Note: truecolor is not supported in CI. Hence, it should be disabled when writing the tests
+
     #[test]
     fn test_block_printer_e2e() {
         let img = DynamicImage::ImageRgba8(image::RgbaImage::new(5, 4));
         let mut buf = Ansi::new(vec![]);
 
-        let config = Config::default();
+        let config = Config {
+            truecolor: false,
+            ..Default::default()
+        };
 
         let (w, h) = print_to_writecolor(&mut buf, &img, &config).unwrap();
         assert_eq!((w, h), (5, 2));
 
         assert_eq!(
             std::str::from_utf8(buf.get_ref()).unwrap(),
-            "\x1b[1;1H\x1b[0m\x1b[38;2;153;153;153m\x1b[48;2;102;102;102m▄\x1b[0m\x1b[38;2;102;102;102m\x1b[48;2;153;153;153m▄\x1b[0m\x1b[38;2;153;153;153m\x1b[48;2;102;102;102m▄\x1b[0m\x1b[38;2;102;102;102m\x1b[48;2;153;153;153m▄\x1b[0m\x1b[38;2;153;153;153m\x1b[48;2;102;102;102m▄\x1b[0m\n\x1b[0m\x1b[38;2;153;153;153m\x1b[48;2;102;102;102m▄\x1b[0m\x1b[38;2;102;102;102m\x1b[48;2;153;153;153m▄\x1b[0m\x1b[38;2;153;153;153m\x1b[48;2;102;102;102m▄\x1b[0m\x1b[38;2;102;102;102m\x1b[48;2;153;153;153m▄\x1b[0m\x1b[38;2;153;153;153m\x1b[48;2;102;102;102m▄\x1b[0m\n"
+            "\x1b[1;1H\x1b[0m\x1b[38;5;247m\x1b[48;5;241m▄\x1b[0m\x1b[38;5;241m\x1b[48;5;247m▄\x1b[0m\x1b[38;5;247m\x1b[48;5;241m▄\x1b[0m\x1b[38;5;241m\x1b[48;5;247m▄\x1b[0m\x1b[38;5;247m\x1b[48;5;241m▄\x1b[0m\n\x1b[0m\x1b[38;5;247m\x1b[48;5;241m▄\x1b[0m\x1b[38;5;241m\x1b[48;5;247m▄\x1b[0m\x1b[38;5;247m\x1b[48;5;241m▄\x1b[0m\x1b[38;5;241m\x1b[48;5;247m▄\x1b[0m\x1b[38;5;247m\x1b[48;5;241m▄\x1b[0m\n"
         );
     }
 
@@ -223,7 +228,7 @@ mod tests {
         let mut buf = Ansi::new(vec![]);
 
         let config = Config {
-            width: Some(20),
+            truecolor: false,
             absolute_offset: false,
             ..Default::default()
         };
@@ -232,7 +237,7 @@ mod tests {
 
         assert_eq!(
             std::str::from_utf8(buf.get_ref()).unwrap(),
-            "\x1b[0m\x1b[38;2;153;153;153m\x1b[48;2;102;102;102m▄\x1b[0m\x1b[38;2;102;102;102m\x1b[48;2;153;153;153m▄\x1b[0m\x1b[38;2;153;153;153m\x1b[48;2;102;102;102m▄\x1b[0m\x1b[38;2;102;102;102m\x1b[48;2;153;153;153m▄\x1b[0m\n\x1b[0m\x1b[38;2;102;102;102m▀\x1b[0m\x1b[38;2;153;153;153m▀\x1b[0m\x1b[38;2;102;102;102m▀\x1b[0m\x1b[38;2;153;153;153m▀\x1b[0m\n"
+            "\x1b[0m\x1b[38;5;247m\x1b[48;5;241m▄\x1b[0m\x1b[38;5;241m\x1b[48;5;247m▄\x1b[0m\x1b[38;5;247m\x1b[48;5;241m▄\x1b[0m\x1b[38;5;241m\x1b[48;5;247m▄\x1b[0m\n\x1b[0m\x1b[38;5;241m▀\x1b[0m\x1b[38;5;247m▀\x1b[0m\x1b[38;5;241m▀\x1b[0m\x1b[38;5;247m▀\x1b[0m\n"
         );
     }
 
@@ -308,12 +313,14 @@ mod tests {
         let mut buf = Ansi::new(vec![]);
         let mut c = ColorSpec::new();
 
+        // test with no color
         write_colored_character(&mut buf, &c, true).unwrap();
         assert_eq!(std::str::from_utf8(buf.get_ref()).unwrap(), "\x1b[1C");
 
         c.set_fg(Some(Color::Rgb(10, 20, 30)));
-        let mut buf = Ansi::new(vec![]);
 
+        // test with fg (unusual case)
+        let mut buf = Ansi::new(vec![]);
         write_colored_character(&mut buf, &c, true).unwrap();
         assert_eq!(std::str::from_utf8(buf.get_ref()).unwrap(), "\x1b[1C");
     }

--- a/src/printer/block.rs
+++ b/src/printer/block.rs
@@ -165,10 +165,9 @@ fn write_colored_character(
     Ok(())
 }
 
+#[inline]
 fn is_pixel_transparent(pixel: (u32, u32, &Rgba<u8>)) -> bool {
-    //TODO: pixel.2[3] ?
-    let (_x, _y, data) = pixel;
-    data[3] == 0
+    pixel.2[3] == 0
 }
 
 fn get_transparency_color(row: u32, col: u32, truecolor: bool) -> Color {

--- a/src/printer/iterm.rs
+++ b/src/printer/iterm.rs
@@ -108,7 +108,7 @@ mod tests {
         };
         let mut vec = Vec::new();
 
-        assert_eq!(iTermPrinter.print(&mut vec, &img, &config).unwrap(), (2, 1));
-        assert_eq!(std::str::from_utf8(&vec).unwrap(), "\x1b[4;5H\x1b]1337;File=inline=1;preserveAspectRatio=1;size=74;width=2;height=1:iVBORw0KGgoAAAANSUhEUgAAAAIAAAADCAYAAAC56t6BAAAAEUlEQVR4nGNkgAJUBhMLGwcAAHkAGFlFRLoAAAAASUVORK5CYII=\x07\n");
+        assert_eq!(iTermPrinter.print(&mut vec, &img, &config).unwrap(), (2, 2));
+        assert_eq!(std::str::from_utf8(&vec).unwrap(), "\x1b[4;5H\x1b]1337;File=inline=1;preserveAspectRatio=1;size=74;width=2;height=2:iVBORw0KGgoAAAANSUhEUgAAAAIAAAADCAYAAAC56t6BAAAAEUlEQVR4nGNkgAJUBhMLGwcAAHkAGFlFRLoAAAAASUVORK5CYII=\x07\n");
     }
 }

--- a/src/printer/iterm.rs
+++ b/src/printer/iterm.rs
@@ -6,7 +6,7 @@ use lazy_static::lazy_static;
 use std::io::{BufReader, Read, Write};
 
 #[allow(non_camel_case_types)]
-pub struct iTermPrinter {}
+pub struct iTermPrinter;
 
 lazy_static! {
     static ref ITERM_SUPPORT: bool = check_iterm_support();
@@ -18,7 +18,12 @@ pub fn is_iterm_supported() -> bool {
 }
 
 impl Printer for iTermPrinter {
-    fn print(&self, img: &DynamicImage, config: &Config) -> ViuResult<(u32, u32)> {
+    fn print(
+        &self,
+        stdout: &mut impl Write,
+        img: &DynamicImage,
+        config: &Config,
+    ) -> ViuResult<(u32, u32)> {
         let (width, height) = img.dimensions();
 
         // Transform the dynamic image to a PNG which can be given directly to iTerm
@@ -33,7 +38,12 @@ impl Printer for iTermPrinter {
         print_buffer(img, &png_bytes[..], config)
     }
 
-    fn print_from_file(&self, filename: &str, config: &Config) -> ViuResult<(u32, u32)> {
+    fn print_from_file(
+        &self,
+        stdout: &mut impl Write,
+        filename: &str,
+        config: &Config,
+    ) -> ViuResult<(u32, u32)> {
         let file = std::fs::File::open(filename)?;
 
         // load the file content

--- a/src/printer/kitty.rs
+++ b/src/printer/kitty.rs
@@ -219,7 +219,7 @@ mod tests {
         };
 
         let mut vec = Vec::new();
-        print_local(&mut vec, &img, &config).unwrap();
+        assert_eq!(print_local(&mut vec, &img, &config).unwrap(), (40, 12));
         let result = std::str::from_utf8(&vec).unwrap();
 
         assert!(result.starts_with("\x1b[4;5H\x1b_Gf=32,s=40,v=25,c=40,r=12,a=T,t=t;"));
@@ -238,7 +238,7 @@ mod tests {
         };
 
         let mut vec = Vec::new();
-        print_remote(&mut vec, &img, &config).unwrap();
+        assert_eq!(print_remote(&mut vec, &img, &config).unwrap(), (1, 1));
         let result = std::str::from_utf8(&vec).unwrap();
 
         assert_eq!(

--- a/src/printer/kitty.rs
+++ b/src/printer/kitty.rs
@@ -227,7 +227,7 @@ mod tests {
     }
 
     #[test]
-    fn test_print_rempte() {
+    fn test_print_remote() {
         let mut img = DynamicImage::ImageRgba8(image::RgbaImage::new(1, 2));
         img.put_pixel(0, 1, image::Rgba([2, 4, 6, 8]));
 

--- a/src/printer/kitty.rs
+++ b/src/printer/kitty.rs
@@ -7,7 +7,7 @@ use lazy_static::lazy_static;
 use std::io::Write;
 use std::io::{Error, ErrorKind};
 
-pub struct KittyPrinter {}
+pub struct KittyPrinter;
 
 lazy_static! {
     static ref KITTY_SUPPORT: KittySupport = check_kitty_support();
@@ -19,7 +19,12 @@ pub fn get_kitty_support() -> KittySupport {
 }
 
 impl Printer for KittyPrinter {
-    fn print(&self, img: &image::DynamicImage, config: &Config) -> ViuResult<(u32, u32)> {
+    fn print(
+        &self,
+        stdout: &mut impl Write,
+        img: &image::DynamicImage,
+        config: &Config,
+    ) -> ViuResult<(u32, u32)> {
         match get_kitty_support() {
             KittySupport::None => Err(ViuError::KittyNotSupported),
             KittySupport::Local => {

--- a/src/printer/kitty.rs
+++ b/src/printer/kitty.rs
@@ -219,10 +219,10 @@ mod tests {
         };
 
         let mut vec = Vec::new();
-        assert_eq!(print_local(&mut vec, &img, &config).unwrap(), (40, 12));
+        assert_eq!(print_local(&mut vec, &img, &config).unwrap(), (40, 13));
         let result = std::str::from_utf8(&vec).unwrap();
 
-        assert!(result.starts_with("\x1b[4;5H\x1b_Gf=32,s=40,v=25,c=40,r=12,a=T,t=t;"));
+        assert!(result.starts_with("\x1b[4;5H\x1b_Gf=32,s=40,v=25,c=40,r=13,a=T,t=t;"));
         assert!(result.ends_with("\x1b\\\n"));
     }
 

--- a/src/printer/kitty.rs
+++ b/src/printer/kitty.rs
@@ -9,6 +9,7 @@ use std::io::{Error, ErrorKind};
 
 pub struct KittyPrinter;
 
+const TEMP_FILE_PREFIX: &str = ".tmp.viuer.";
 lazy_static! {
     static ref KITTY_SUPPORT: KittySupport = check_kitty_support();
 }
@@ -29,11 +30,11 @@ impl Printer for KittyPrinter {
             KittySupport::None => Err(ViuError::KittyNotSupported),
             KittySupport::Local => {
                 // print from file
-                print_local(img, config)
+                print_local(stdout, img, config)
             }
             KittySupport::Remote => {
                 // print through escape codes
-                print_remote(img, config)
+                print_remote(stdout, img, config)
             }
         }
     }
@@ -116,13 +117,16 @@ fn has_local_support() -> ViuResult {
 
 // Print with kitty graphics protocol through a temp file
 // TODO: try with kitty's supported compression
-fn print_local(img: &image::DynamicImage, config: &Config) -> ViuResult<(u32, u32)> {
+fn print_local(
+    stdout: &mut impl Write,
+    img: &image::DynamicImage,
+    config: &Config,
+) -> ViuResult<(u32, u32)> {
     let rgba = img.to_rgba8();
     let raw_img = rgba.as_raw();
     let path = store_in_tmp_file(raw_img)?;
 
-    let mut stdout = std::io::stdout();
-    adjust_offset(&mut stdout, config)?;
+    adjust_offset(stdout, config)?;
 
     // get the desired width and height
     let (w, h) = find_best_fit(&img, config.width, config.height);
@@ -147,14 +151,17 @@ fn print_local(img: &image::DynamicImage, config: &Config) -> ViuResult<(u32, u3
 
 // Print with escape codes
 // TODO: try compression
-fn print_remote(img: &image::DynamicImage, config: &Config) -> ViuResult<(u32, u32)> {
+fn print_remote(
+    stdout: &mut impl Write,
+    img: &image::DynamicImage,
+    config: &Config,
+) -> ViuResult<(u32, u32)> {
     let rgba = img.to_rgba8();
     let raw = rgba.as_raw();
     let encoded = base64::encode(raw);
     let mut iter = encoded.chars().peekable();
 
-    let mut stdout = std::io::stdout();
-    adjust_offset(&mut stdout, config)?;
+    adjust_offset(stdout, config)?;
 
     let (w, h) = find_best_fit(&img, config.width, config.height);
 
@@ -185,7 +192,7 @@ fn print_remote(img: &image::DynamicImage, config: &Config) -> ViuResult<(u32, u
 // Create a file in temporary dir and write the byte slice to it.
 fn store_in_tmp_file(buf: &[u8]) -> std::result::Result<std::path::PathBuf, ViuError> {
     let (mut tmpfile, path) = tempfile::Builder::new()
-        .prefix(".tmp.viuer.")
+        .prefix(TEMP_FILE_PREFIX)
         .rand_bytes(1)
         .tempfile()?
         // Since the file is persisted, the user is responsible for deleting it afterwards. However,
@@ -195,4 +202,48 @@ fn store_in_tmp_file(buf: &[u8]) -> std::result::Result<std::path::PathBuf, ViuE
     tmpfile.write_all(buf)?;
     tmpfile.flush()?;
     Ok(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use image::{DynamicImage, GenericImage};
+
+    #[test]
+    fn test_print_local() {
+        let img = DynamicImage::ImageRgba8(image::RgbaImage::new(40, 25));
+        let config = Config {
+            x: 4,
+            y: 3,
+            ..Default::default()
+        };
+
+        let mut vec = Vec::new();
+        print_local(&mut vec, &img, &config).unwrap();
+        let result = std::str::from_utf8(&vec).unwrap();
+
+        assert!(result.starts_with("\x1b[4;5H\x1b_Gf=32,s=40,v=25,c=40,r=12,a=T,t=t;"));
+        assert!(result.ends_with("\x1b\\\n"));
+    }
+
+    #[test]
+    fn test_print_rempte() {
+        let mut img = DynamicImage::ImageRgba8(image::RgbaImage::new(1, 2));
+        img.put_pixel(0, 1, image::Rgba([2, 4, 6, 8]));
+
+        let config = Config {
+            x: 2,
+            y: 5,
+            ..Default::default()
+        };
+
+        let mut vec = Vec::new();
+        print_remote(&mut vec, &img, &config).unwrap();
+        let result = std::str::from_utf8(&vec).unwrap();
+
+        assert_eq!(
+            result,
+            "\x1b[6;3H\x1b_Gf=32,a=T,t=d,s=1,v=2,c=1,r=1,m=1;AAAAAAIEBgg=\x1b\\\n"
+        );
+    }
 }

--- a/src/printer/mod.rs
+++ b/src/printer/mod.rs
@@ -172,7 +172,7 @@ fn fit_dimensions(width: u32, height: u32, bound_width: u32, bound_height: u32) 
     };
 
     if use_width {
-        (bound_width, std::cmp::max(1, intermediate / 2 + height % 2))
+        (bound_width, std::cmp::max(1, intermediate / 2))
     } else {
         (intermediate, std::cmp::max(1, bound_height / 2))
     }
@@ -218,7 +218,7 @@ mod tests {
     }
 
     fn best_fit_large_test_image() -> DynamicImage {
-        DynamicImage::ImageRgba8(image::RgbaImage::new(600, 500))
+        DynamicImage::ImageRgba8(image::RgbaImage::new(600, 499))
     }
 
     fn best_fit_small_test_image() -> DynamicImage {
@@ -259,7 +259,7 @@ mod tests {
         let img = resize_get_large_test_image();
         let new_img = resize(&img, width, height);
         assert_eq!(new_img.width(), 100);
-        assert_eq!(new_img.height(), 79);
+        assert_eq!(new_img.height(), 77);
 
         let img = resize_get_small_test_image();
         let new_img = resize(&img, width, height);
@@ -341,7 +341,7 @@ mod tests {
         let width = Some(6);
         let (w, h) = find_best_fit(&img, width, height);
         assert_eq!(w, 6);
-        assert_eq!(h, 2);
+        assert_eq!(h, 1);
 
         let width = Some(3);
         let (w, h) = find_best_fit(&img, width, height);

--- a/src/printer/sixel.rs
+++ b/src/printer/sixel.rs
@@ -8,7 +8,7 @@ use sixel_rs::encoder::{Encoder, QuickFrameBuilder};
 use sixel_rs::optflags::EncodePolicy;
 use std::io::Write;
 
-pub struct SixelPrinter {}
+pub struct SixelPrinter;
 
 lazy_static! {
     static ref SIXEL_SUPPORT: bool = check_sixel_support();
@@ -20,7 +20,12 @@ pub fn is_sixel_supported() -> bool {
 }
 
 impl Printer for SixelPrinter {
-    fn print(&self, img: &DynamicImage, config: &Config) -> ViuResult<(u32, u32)> {
+    fn print(
+        &self,
+        stdout: &mut impl Write,
+        img: &DynamicImage,
+        config: &Config,
+    ) -> ViuResult<(u32, u32)> {
         let (w, h) = find_best_fit(&img, config.width, config.height);
 
         //TODO: the max 1000 width is an xterm bug workaround, other terminals may not be affected
@@ -32,8 +37,7 @@ impl Printer for SixelPrinter {
         let rgba = resized_img.to_rgba8();
         let raw = rgba.as_raw();
 
-        let mut stdout = std::io::stdout();
-        adjust_offset(&mut stdout, config)?;
+        adjust_offset(stdout, config)?;
 
         let encoder = Encoder::new()?;
 


### PR DESCRIPTION
The aim of this PR was to change the trait's signatures so that an `impl std::io::Write` variable can be passed. During tests, that could be a `Vec` and provide a way to `assert!` functions' output.

Unfortunately, I got off track and refactored the block printer, too. Hopefully, it is a little simpler now. And not a terribly large amount of bugs were introduced..