### PR TITLE
Add foot as supported sixel term

### DIFF
--- a/src/printer/sixel.rs
+++ b/src/printer/sixel.rs
@@ -82,7 +82,7 @@ fn check_device_attrs() -> ViuResult<bool> {
 fn check_sixel_support() -> bool {
     if let Ok(term) = std::env::var("TERM") {
         match term.as_str() {
-            "mlterm" | "yaft-256color" => return true,
+            "mlterm" | "yaft-256color" | "foot" => return true,
             "st-256color" | "xterm" | "xterm-256color" => {
                 return check_device_attrs().unwrap_or(false)
             }


### PR DESCRIPTION
[Foot](https://codeberg.org/dnkl/foot/) terminal natively supports sixel. I have tested [viu](https://github.com/atanunq/viu) on my branch and it works perfectly on foot. See snippet below.

![image](https://user-images.githubusercontent.com/59267627/115311262-466a3100-a167-11eb-88ec-0f3a79ddcfb4.png)
