### PR TITLE
Extensions of print* functions with custom output streams

### DIFF
--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Atanas Yankov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Viuer is awesome! But its capabilities could be utilized even further if we let users customize output streams. Current public API helper functions are sealed with `stdout`, so the user doesn't have alternatives rather than printing images directly to stdout. I added two new helper functions `write` and `write_from_file` that work exactly the same way as `print`* functions do, but they also accept `&mut impl Write` as a first additional argument.

The primary motivation for me to introduce this extension is making a custom implementation of the [Rust Env Logger](https://github.com/env-logger-rs/env_logger/) for my own graphics project, such that the logger will be able to print images to terminal for the logs referring GPU backed image in debug messages. This is practically useful for visual debugging of the rendering process, and is a nice feature to have. The difficulty here is that the Logger Builder [callback](https://env-logger-rs.github.io/env_logger/env_logger/struct.Builder.html#method.format) tied to the `Formatter` which in turn is a `Write` implementation, and requires of buffering printing data beforehand. If I use just `print`/`print_from_file` functions the images would come to console before the log message.

All in all with these new functions the end result looks good:
![Screenshot from 2021-09-26 13-56-59](https://user-images.githubusercontent.com/223986/134797143-1c07c37a-0f8a-412e-814e-e41cb6f2b2b5.png)

I also added MIT License file to this repo to match the record in Cargo manifest.

