### PR TITLE
Detect iTerm protocol from $LC_TERMINAL too

### DIFF
--- a/src/printer/iterm.rs
+++ b/src/printer/iterm.rs
@@ -91,6 +91,11 @@ fn check_iterm_support() -> bool {
             return true;
         }
     }
+    if let Ok(lc_term) = std::env::var("LC_TERMINAL") {
+        if lc_term.contains("iTerm") || lc_term.contains("WezTerm") || lc_term.contains("mintty") {
+            return true;
+        }
+    }
     false
 }
 


### PR DESCRIPTION
When checking whether the iTerm protocol is available, check the `LC_TERMINAL` environment variable in addition to `TERM_PROGRAM`. `LC_TERMINAL` is passed to many remote hosts; read on for details.

----

iTerm2 sets the environment variable `LC_TERMINAL` to `iTerm2`. This is useful because on Debian and Ubuntu systems*, the default `/etc/ssh/sshd_config` contains the line:

```
AcceptEnv LANG LC_*
```

That is, if the ssh client sends the `LC_TERMINAL` variable, it will be added to the login environment. macOS has this configuration in `/etc/ssh/sshd_config.d/100-macos.conf` as well. macOS's default `/etc/ssh/ssh_config` contains

```
Host *
    SendEnv LANG LC_*
```

so macOS ssh clients all pass LC_TERMINAL. Debian and Ubuntu do this too.

*: Checked Ubuntu 16.04, 18.04, 20.04, 22.04; Debian 9.9, 10.12,
11.3, current sid.