### PR TITLE
Upgrade sixel-rs dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,14 +21,11 @@ base64 = "0.13"
 tempfile = "3.1"
 console = { version = "0.15", default-features = false }
 lazy_static = "1.4"
-sixel-sys = { version = "0.3.1", optional = true }
 
-# avoid feature and crate name collision (thanks rabite0/hunter)
 [dependencies.sixel-rs]
-package = "sixel"
-version = "0.3.2"
+version = "0.3.3"
 optional = true
 
 [features]
 default = []
-sixel = ["sixel-rs", "sixel-sys"]
+sixel = ["sixel-rs"]

--- a/src/printer/sixel.rs
+++ b/src/printer/sixel.rs
@@ -46,7 +46,7 @@ impl Printer for SixelPrinter {
         let frame = QuickFrameBuilder::new()
             .width(width as usize)
             .height(height as usize)
-            .format(sixel_sys::PixelFormat::RGBA8888)
+            .format(sixel_rs::sys::PixelFormat::RGBA8888)
             .pixels(raw.to_vec());
 
         encoder.encode_bytes(frame)?;


### PR DESCRIPTION
This PR fixes the following security vulnerabilities:

- [RUSTSEC-2022-0013](https://rustsec.org/advisories/RUSTSEC-2022-0013.html)
- [RUSTSEC-2022-0006](https://rustsec.org/advisories/RUSTSEC-2022-0006.html)

Fixes #39
