### PR TITLE
Do not stretch option for kitty

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ tempfile = "3.1"
 console = { version = "0.15", default-features = false }
 lazy_static = "1.4"
 sixel-sys = { version = "0.3.1", optional = true }
+nix = {version = "0.25.0", default-feature = false, features = [ "ioctl" ]}
 
 # avoid feature and crate name collision (thanks rabite0/hunter)
 [dependencies.sixel-rs]

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,6 +20,9 @@ pub struct Config {
     pub width: Option<u32>,
     /// Optional image height. Defaults to None.
     pub height: Option<u32>,
+    /// Do not stretch the image to fill the cells. Defaults to true.
+    /// Valid only for kitty graphics protocol
+    pub do_not_stretch: bool,
     /// Use truecolor if the terminal supports it. Defaults to true.
     pub truecolor: bool,
     /// Use Kitty protocol if the terminal supports it. Defaults to true.
@@ -41,6 +44,7 @@ impl std::default::Default for Config {
             restore_cursor: false,
             width: None,
             height: None,
+            do_not_stretch: true,
             truecolor: utils::truecolor_available(),
             use_kitty: true,
             use_iterm: true,


### PR DESCRIPTION
Proposal for solving #45 for Kitty

To test:
```rust
use viuer::{Config, print_from_file};

fn main() {

    let img = "image.png";

    let conf = Config {
        absolute_offset: false,
        do_not_stretch: false,
        ..Default::default()
    };
    dbg!(conf.do_not_stretch);
    print_from_file(img, &conf).expect("Image printing failed.");

    let conf = Config {
        absolute_offset: false,
        ..Default::default()
    };
    dbg!(conf.do_not_stretch);
    print_from_file(img, &conf).expect("Image printing failed.");
}
```