### PR TITLE
Update kitty temp file naming

### DIFF
--- a/src/printer/kitty.rs
+++ b/src/printer/kitty.rs
@@ -8,7 +8,7 @@ use std::io::{Error, ErrorKind};
 
 pub struct KittyPrinter;
 
-const TEMP_FILE_PREFIX: &str = ".tmp.viuer.";
+const TEMP_FILE_PREFIX: &str = ".tty-graphics-protocol.viuer.";
 lazy_static! {
     static ref KITTY_SUPPORT: KittySupport = check_kitty_support();
 }


### PR DESCRIPTION
Kitty will now only remove temp files if they contain `tty-graphics-protocol` in the path. With viuer's current naming scheme, this will lead to eventually running out of tmp files and viuer hanging. By changing the name to include `tty-graphics-protocol`, kitty will always delete the tmp file.