### PR TITLE
Allow configuring kitty's z-index option

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,8 @@ pub struct Config {
     pub x: u16,
     /// Y offset. Can be negative only when `absolute_offset` is `false`. Defaults to 0.
     pub y: i16,
+    /// Z offset. This takes effect in terminals that support this.
+    pub z: i32,
     /// Take a note of cursor position before printing and restore it when finished.
     /// Defaults to false.
     pub restore_cursor: bool,
@@ -38,6 +40,7 @@ impl std::default::Default for Config {
             absolute_offset: true,
             x: 0,
             y: 0,
+            z: 0,
             restore_cursor: false,
             width: None,
             height: None,

--- a/src/printer/kitty.rs
+++ b/src/printer/kitty.rs
@@ -134,11 +134,12 @@ fn print_local(
 
     write!(
         stdout,
-        "\x1b_Gf=32,s={},v={},c={},r={},a=T,t=t;{}\x1b\\",
+        "\x1b_Gf=32,s={},v={},c={},r={},a=T,t=t,z={};{}\x1b\\",
         img.width(),
         img.height(),
         w,
         h,
+        config.z,
         general_purpose::STANDARD.encode(path.to_str().ok_or_else(|| ViuError::Io(Error::new(
             ErrorKind::Other,
             "Could not convert path to &str"
@@ -171,11 +172,12 @@ fn print_remote(
     // write the first chunk, which describes the image
     write!(
         stdout,
-        "\x1b_Gf=32,a=T,t=d,s={},v={},c={},r={},m=1;{}\x1b\\",
+        "\x1b_Gf=32,a=T,t=d,s={},v={},c={},r={},m=1,z={};{}\x1b\\",
         img.width(),
         img.height(),
         w,
         h,
+        config.z,
         first_chunk
     )?;
 
@@ -223,7 +225,7 @@ mod tests {
         assert_eq!(print_local(&mut vec, &img, &config).unwrap(), (40, 13));
         let result = std::str::from_utf8(&vec).unwrap();
 
-        assert!(result.starts_with("\x1b[4;5H\x1b_Gf=32,s=40,v=25,c=40,r=13,a=T,t=t;"));
+        assert!(result.starts_with("\x1b[4;5H\x1b_Gf=32,s=40,v=25,c=40,r=13,a=T,t=t,z=0;"));
         assert!(result.ends_with("\x1b\\\n"));
     }
 
@@ -244,7 +246,7 @@ mod tests {
 
         assert_eq!(
             result,
-            "\x1b[6;3H\x1b_Gf=32,a=T,t=d,s=1,v=2,c=1,r=1,m=1;AAAAAAIEBgg=\x1b\\\n"
+            "\x1b[6;3H\x1b_Gf=32,a=T,t=d,s=1,v=2,c=1,r=1,m=1,z=0;AAAAAAIEBgg=\x1b\\\n"
         );
     }
 }


### PR DESCRIPTION
This adds support for kitty's [z-index option](https://sw.kovidgoyal.net/kitty/graphics-protocol/#controlling-displayed-image-layout). This allows controlling the stacking of images and whether they're shown behind the text/background. By default this uses z-index = 0, which should be the same as before.

This is a breaking change as any code that was creating a `Config` by filling in all the fields will now fail to compile. I'm open to alternative ways to add this if this is an issue.