### PR TITLE
Add emacs-eat to list of sixel-supporting emulators

### DIFF
--- a/src/printer/sixel.rs
+++ b/src/printer/sixel.rs
@@ -82,7 +82,7 @@ fn check_device_attrs() -> ViuResult<bool> {
 fn check_sixel_support() -> bool {
     if let Ok(term) = std::env::var("TERM") {
         match term.as_str() {
-            "mlterm" | "yaft-256color" | "foot" | "foot-extra" => return true,
+            "mlterm" | "yaft-256color" | "foot" | "foot-extra" | "eat-truecolor" => return true,
             "st-256color" | "xterm" | "xterm-256color" => {
                 return check_device_attrs().unwrap_or(false)
             }


### PR DESCRIPTION
Hi there,

I've been using emacs-eat (https://codeberg.org/akib/emacs-eat) with Spotify Player (https://github.com/aome510/spotify-player) which uses this library to render album-art images. If I set `TERM=mlterm`, then run `spotify_player`, emacs-eat can render the album art without issue:

<img width="800" alt="Screenshot 2024-02-21 at 23 45 15" src="https://github.com/atanunq/viuer/assets/101739/e503e7d0-1ffe-4085-8ae2-097effaed2ec">

This PR simply adds emacs-eat's `TERM` value to this library, so that the sixel rendering can happen without overriding `TERM`.