### PR TITLE
Added support for proper alpha blending, limited & updated dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+- Remove unneeded features and update dependencies
+- Use Catmull-Rom for up/downscaling
+- Add `premultiplied_alpha` Config option
+
 ## 0.7.1
 - Bump `base64` and `crossterm` dependencies
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,17 +13,17 @@ keywords = ["terminal", "image"]
 exclude = [".github"]
 
 [dependencies]
-termcolor = "1.1"
-crossterm = "0.27"
-ansi_colours = "1.0"
-image = "0.24"
-base64 = "0.21.4"
-tempfile = "3.1"
+ansi_colours = "1"
+base64 = "0.22"
 console = { version = "0.15", default-features = false }
-lazy_static = "1.4"
+crossterm = "0.28"
+image = "0.25"
+lazy_static = "1.5"
+tempfile = "3"
+termcolor = "1"
 
 [dependencies.sixel-rs]
-version = "0.3.3"
+version = "0.3"
 optional = true
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [".github"]
 ansi_colours = "1"
 base64 = "0.22"
 console = { version = "0.15", default-features = false }
-crossterm = "0.28"
+crossterm = { version = "0.28", default-features = false }
 image = { version = "0.25", default-features = false, features = [
     "rayon",
     "png",
@@ -28,6 +28,11 @@ termcolor = "1"
 [dependencies.sixel-rs]
 version = "0.3"
 optional = true
+
+[target.'cfg(windows)'.dependencies]
+crossterm = { version = "0.28", default-features = false, features = [
+    "windows",
+] }
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,10 @@ ansi_colours = "1"
 base64 = "0.22"
 console = { version = "0.15", default-features = false }
 crossterm = "0.28"
-image = "0.25"
+image = { version = "0.25", default-features = false, features = [
+    "rayon",
+    "png",
+] }
 lazy_static = "1.5"
 tempfile = "3"
 termcolor = "1"

--- a/README.md
+++ b/README.md
@@ -1,27 +1,40 @@
-# viuer
+# `viuer`
+
 Display images in the terminal with ease.
+
+> This clone of the original repository has the following changes:
+>
+> - Real alpha compositing for the checkerboard background (instead of one bit
+>   transparency)
+> - Uses Catmull-Rom for up/downscaling.
+> - Updated dependencies.
 
 ![ci](https://github.com/atanunq/viuer/workflows/ci/badge.svg)
 
-`viuer` is a Rust library that makes it easy to show images in the
-terminal. It has a straightforward interface and is configured
-through a single struct. The default printing method is through
-lower half blocks (▄ or \u2585). However some custom graphics
-protocols are supported. They result in full resolution images
-being displayed in specific environments:
+`viuer` is a Rust library that makes it easy to show images in the terminal.
+It has a straightforward interface and is configured through a single struct.
+The default printing method is through lower half blocks (▄ or \u2585).
+However some custom graphics protocols are supported. They result in full
+resolution images being displayed in specific environments:
 
 - [Kitty](https://sw.kovidgoyal.net/kitty/graphics-protocol.html)
+
 - [iTerm](https://iterm2.com/documentation-images.html)
-- [Sixel](https://github.com/saitoha/libsixel) (behind the "sixel" feature gate)
+
+- [Sixel](https://github.com/saitoha/libsixel) (behind the "sixel"
+  feature gate)
 
 ## Usage
+
 Add this to `Cargo.toml`:
+
 ```toml
 [dependencies]
-viuer = "0.6"
+viuer = "0.7"
 ```
 
-For a demo of the library's usage and example screenshots, see [`viu`](https://github.com/atanunq/viu).
+For a demo of the library's usage and example screenshots, see
+[`viu`](https://github.com/atanunq/viu).
 
 ## Examples
 
@@ -47,7 +60,9 @@ fn main() {
 }
 ```
 
-Or if you have a [DynamicImage](https://docs.rs/image/*/image/enum.DynamicImage.html), you can use it directly:
+Or if you have a [DynamicImage](https://docs.rs/image/*/image/enum.DynamicImage.html),
+you can use it directly:
+
 ```rust
 // ..Config setup
 
@@ -56,4 +71,6 @@ viuer::print(&img, &conf).expect("Image printing failed.");
 ```
 
 ## Docs
-Check the [full documentation](https://docs.rs/crate/viuer) for examples and all the configuration options.
+
+Check the [full documentation](https://docs.rs/crate/viuer) for examples and all
+the configuration options.

--- a/README.md
+++ b/README.md
@@ -4,14 +4,6 @@
 
 Display images in the terminal with ease.
 
-> This clone of the original repository has the following changes:
->
-> - Real alpha compositing for the checkerboard background (instead of one bit
->   transparency).
-> - Support for pre-multiplied alpha blending (new flag in `Config`).
-> - Uses Catmull-Rom for up/downscaling.
-> - Updated dependencies.
-
 `viuer` is a Rust library that makes it easy to show images in the terminal.
 It has a straightforward interface and is configured through a single struct.
 The default printing method is through lower half blocks (`▄` or `\u2585`).
@@ -29,7 +21,7 @@ Add this to `Cargo.toml`:
 
 ```toml
 [dependencies]
-viuer = "0.7"
+viuer = "0.8"
 ```
 
 For a demo of the library's usage and example screenshots, see

--- a/README.md
+++ b/README.md
@@ -8,12 +8,13 @@ Display images in the terminal with ease.
 >
 > - Real alpha compositing for the checkerboard background (instead of one bit
 >   transparency).
+> - Support for pre-multiplied alpha blending (new flag in `Config`).
 > - Uses Catmull-Rom for up/downscaling.
 > - Updated dependencies.
 
 `viuer` is a Rust library that makes it easy to show images in the terminal.
 It has a straightforward interface and is configured through a single struct.
-The default printing method is through lower half blocks (▄ or \u2585).
+The default printing method is through lower half blocks (`▄` or `\u2585`).
 However some custom graphics protocols are supported. They result in full
 resolution images being displayed in specific environments:
 
@@ -61,7 +62,7 @@ Or if you have a [DynamicImage](https://docs.rs/image/*/image/enum.DynamicImage.
 you can use it directly:
 
 ```rust
-// ..Config setup
+// ... `Config` setup
 
 let img = image::DynamicImage::ImageRgba8(image::RgbaImage::new(20, 10));
 viuer::print(&img, &conf).expect("Image printing failed.");

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # `viuer`
 
+![ci](https://github.com/atanunq/viuer/workflows/ci/badge.svg)
+
 Display images in the terminal with ease.
 
 > This clone of the original repository has the following changes:
 >
 > - Real alpha compositing for the checkerboard background (instead of one bit
->   transparency)
+>   transparency).
 > - Uses Catmull-Rom for up/downscaling.
 > - Updated dependencies.
-
-![ci](https://github.com/atanunq/viuer/workflows/ci/badge.svg)
 
 `viuer` is a Rust library that makes it easy to show images in the terminal.
 It has a straightforward interface and is configured through a single struct.
@@ -18,10 +18,8 @@ However some custom graphics protocols are supported. They result in full
 resolution images being displayed in specific environments:
 
 - [Kitty](https://sw.kovidgoyal.net/kitty/graphics-protocol.html)
-
 - [iTerm](https://iterm2.com/documentation-images.html)
-
-- [Sixel](https://github.com/saitoha/libsixel) (behind the "sixel"
+- [Sixel](https://github.com/saitoha/libsixel) (behind the `sixel`
   feature gate)
 
 ## Usage
@@ -39,23 +37,22 @@ For a demo of the library's usage and example screenshots, see
 ## Examples
 
 ```rust
-// src/main.rs
 use viuer::{print_from_file, Config};
 
 fn main() {
     let conf = Config {
-        // set offset
+        // Set offset.
         x: 20,
         y: 4,
-        // set dimensions
+        // Set dimensions.
         width: Some(80),
         height: Some(25),
         ..Default::default()
     };
 
-    // starting from row 4 and column 20,
-    // display `img.jpg` with dimensions 80x25 (in terminal cells)
-    // note that the actual resolution in the terminal will be 80x50
+    // Starting from row 4 and column 20,
+    // display `img.jpg` with dimensions 80×25 (in terminal cells).
+    // Note that the actual resolution in the terminal will be 80×50.
     print_from_file("img.jpg", &conf).expect("Image printing failed.");
 }
 ```

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,11 +7,11 @@ pub struct Config {
     pub transparent: bool,
     /// If we assume the alpha channel is premultiplied for blending with the
     /// checkerboard background.
-    /// Defaults to true.
+    /// Defaults to false.
     pub premultiplied_alpha: bool,
     /// Make the x and y offset be relative to the top left terminal corner.
     /// If false, the y offset is relative to the cursor's position.
-    /// Defaults to false.
+    /// Defaults to true.
     pub absolute_offset: bool,
     /// X offset. Defaults to 0.
     pub x: u16,

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,13 +5,18 @@ pub struct Config {
     /// Enable true transparency instead of checkerboard background.
     /// Available only for the block printer. Defaults to false.
     pub transparent: bool,
+    /// If we assume the alpha channel is premultiplied for blending with the
+    /// checkerboard background.
+    /// Defaults to true.
+    pub premultiplied_alpha: bool,
     /// Make the x and y offset be relative to the top left terminal corner.
     /// If false, the y offset is relative to the cursor's position.
-    /// Defaults to true.
+    /// Defaults to false.
     pub absolute_offset: bool,
     /// X offset. Defaults to 0.
     pub x: u16,
-    /// Y offset. Can be negative only when `absolute_offset` is `false`. Defaults to 0.
+    /// Y offset. Can be negative only when `absolute_offset` is `false`.
+    /// Defaults to 0.
     pub y: i16,
     /// Take a note of cursor position before printing and restore it when finished.
     /// Defaults to false.
@@ -35,6 +40,7 @@ impl std::default::Default for Config {
     fn default() -> Self {
         Self {
             transparent: false,
+            premultiplied_alpha: false,
             absolute_offset: true,
             x: 0,
             y: 0,

--- a/src/printer/iterm.rs
+++ b/src/printer/iterm.rs
@@ -36,7 +36,7 @@ impl Printer for iTermPrinter {
             img.as_bytes(),
             width,
             height,
-            img.color(),
+            img.color().into(),
         )?;
 
         print_buffer(stdout, img, &png_bytes[..], config)

--- a/src/printer/mod.rs
+++ b/src/printer/mod.rs
@@ -36,7 +36,7 @@ pub trait Printer {
         filename: P,
         config: &Config,
     ) -> ViuResult<(u32, u32)> {
-        let img = image::io::Reader::open(filename)?
+        let img = image::ImageReader::open(filename)?
             .with_guessed_format()?
             .decode()?;
         self.print(stdout, &img, config)
@@ -95,7 +95,7 @@ pub fn resize(img: &DynamicImage, width: Option<u32>, height: Option<u32>) -> Dy
     img.resize_exact(
         w,
         2 * h - img.height() % 2,
-        image::imageops::FilterType::Triangle,
+        image::imageops::FilterType::CatmullRom,
     )
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -40,7 +40,7 @@ pub fn terminal_size() -> (u16, u16) {
     }
 }
 
-// Return a constant when running the tests
+/// Returns a constant and only used when running the tests.
 #[cfg(test)]
 pub fn terminal_size() -> (u16, u16) {
     DEFAULT_TERM_SIZE


### PR DESCRIPTION
See also the README in my branch. You may want to cherry-pick that out btw.

- Real alpha compositing for the checkerboard background (instead of one bit transparency).
- Support for pre-multiplied alpha blending (new flag in `Config`).
- Uses Catmull-Rom for up/downscaling.
- Updated dependencies.
- Removed superfluous dependencies pulled in by `image` crate.
  *This brings down the number of deps **from 129 to 61** (when `--all-features` is passed)!*

Before:
![image](https://github.com/user-attachments/assets/cbbb55dc-57b7-4e12-b75d-41c097c019de)

After:
![image](https://github.com/user-attachments/assets/5a0c21a0-faa1-4b12-9f0f-ba18eba82ca4)
