### PR TITLE
Add experimental support for icy_sixel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,8 @@ image = { version = "0.25", default-features = false, features = ["png"] }
 lazy_static = "1.5"
 tempfile = "3"
 termcolor = "1"
-sixel-rs = { version = "0.3", optional = true}
+sixel-rs = { version = "0.3", optional = true }
+icy_sixel = { version = "0.1", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 crossterm = { version = "0.28", default-features = false, features = ["windows"]}
@@ -29,8 +30,8 @@ crossterm = { version = "0.28", default-features = false, features = ["windows"]
 [features]
 default = []
 sixel = ["sixel-rs"]
+icy_sixel = ["dep:icy_sixel"]
 print-file = ["image/default-formats"] # Hide file printing behind a flag because it adds heavy dependencies.
-
 
 [package.metadata.docs.rs]
 # Show all methods in the documentation, even the non-default ones.

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,7 +32,7 @@ pub struct Config {
     /// Use iTerm protocol if the terminal supports it. Defaults to true.
     pub use_iterm: bool,
     /// Use Sixel protocol if the terminal supports it. Defaults to true.
-    #[cfg(feature = "sixel")]
+    #[cfg(any(feature = "sixel", feature = "icy_sixel"))]
     pub use_sixel: bool,
 }
 
@@ -50,7 +50,7 @@ impl std::default::Default for Config {
             truecolor: utils::truecolor_available(),
             use_kitty: true,
             use_iterm: true,
-            #[cfg(feature = "sixel")]
+            #[cfg(any(feature = "sixel", feature = "icy_sixel"))]
             use_sixel: true,
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,6 +19,9 @@ pub enum ViuError {
     /// Error while printing with sixel
     #[cfg(feature = "sixel")]
     SixelError(sixel_rs::status::Error),
+    /// Boxed generic error.
+    #[cfg(feature = "icy_sixel")]
+    BoxedError(Box<dyn std::error::Error>),
 }
 
 impl std::error::Error for ViuError {}
@@ -47,6 +50,13 @@ impl From<sixel_rs::status::Error> for ViuError {
     }
 }
 
+#[cfg(feature = "icy_sixel")]
+impl From<Box<dyn std::error::Error>> for ViuError {
+    fn from(e: Box<dyn std::error::Error>) -> Self {
+        ViuError::BoxedError(e)
+    }
+}
+
 impl std::fmt::Display for ViuError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -58,6 +68,8 @@ impl std::fmt::Display for ViuError {
             ViuError::KittyNotSupported => write!(f, "Kitty graphics protocol not supported"),
             #[cfg(feature = "sixel")]
             ViuError::SixelError(e) => write!(f, "Sixel error: {:?}", e),
+            #[cfg(feature = "icy_sixel")]
+            ViuError::BoxedError(e) => write!(f, "{:?}", e),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ pub use error::{ViuError, ViuResult};
 pub use printer::{get_kitty_support, is_iterm_supported, resize, KittySupport};
 pub use utils::terminal_size;
 
-#[cfg(feature = "sixel")]
+#[cfg(any(feature = "sixel", feature = "icy_sixel"))]
 pub use printer::is_sixel_supported;
 
 /// Default printing method. Uses either iTerm or Kitty graphics protocol, if supported,
@@ -139,6 +139,11 @@ pub fn print_from_file<P: AsRef<Path>>(filename: P, config: &Config) -> ViuResul
 
 // Choose the appropriate printer to use based on user config and availability
 fn choose_printer(config: &Config) -> PrinterType {
+    #[cfg(feature = "icy_sixel")]
+    if config.use_sixel && is_sixel_supported() {
+        return PrinterType::IcySixel;
+    }
+
     #[cfg(feature = "sixel")]
     if config.use_sixel && is_sixel_supported() {
         return PrinterType::Sixel;

--- a/src/printer/icy_sixel.rs
+++ b/src/printer/icy_sixel.rs
@@ -1,0 +1,43 @@
+use icy_sixel::sixel_string;
+use image::{imageops::FilterType, GenericImageView};
+use super::{adjust_offset, find_best_fit, Printer};
+
+pub struct IcySixelPrinter;
+
+impl Printer for IcySixelPrinter {
+    fn print(
+        &self,
+        stdout: &mut impl std::io::Write,
+        img: &image::DynamicImage,
+        config: &crate::Config,
+    ) -> crate::ViuResult<(u32, u32)> {
+
+        let (w, h) = find_best_fit(img, config.width, config.height);
+
+        //TODO: the max 1000 width is an xterm bug workaround, other terminals may not be affected
+        let resized_img =
+            img.resize_exact(std::cmp::min(6 * w, 1000), 12 * h, FilterType::Triangle);
+
+        let (width, height) = resized_img.dimensions();
+
+        let rgba = resized_img.to_rgba8();
+        let raw = rgba.as_raw();
+
+        adjust_offset(stdout, config)?;
+
+        let output = sixel_string(
+            raw,
+            width as i32,
+            height as i32,
+            icy_sixel::PixelFormat::RGBA8888,
+            icy_sixel::DiffusionMethod::Auto,
+            icy_sixel::MethodForLargest::Auto,
+            icy_sixel::MethodForRep::Auto,
+            icy_sixel::Quality::AUTO)?;
+
+        write!(stdout, "{output}")?;
+        stdout.flush()?;
+
+        Ok((w, h))
+    }
+}

--- a/src/printer/mod.rs
+++ b/src/printer/mod.rs
@@ -18,7 +18,17 @@ pub use kitty::{get_kitty_support, KittyPrinter, KittySupport};
 #[cfg(feature = "sixel")]
 mod sixel;
 #[cfg(feature = "sixel")]
-pub use self::sixel::{is_sixel_supported, SixelPrinter};
+pub use self::sixel::SixelPrinter;
+
+#[cfg(feature = "icy_sixel")]
+mod icy_sixel;
+#[cfg(feature = "icy_sixel")]
+pub use self::icy_sixel::IcySixelPrinter;
+
+#[cfg(any(feature = "sixel", feature = "icy_sixel"))]
+mod sixel_util;
+#[cfg(any(feature = "sixel", feature = "icy_sixel"))]
+pub use self::sixel_util::is_sixel_supported;
 
 mod iterm;
 pub use iterm::iTermPrinter;
@@ -55,6 +65,8 @@ pub enum PrinterType {
     iTerm,
     #[cfg(feature = "sixel")]
     Sixel,
+    #[cfg(feature = "icy_sixel")]
+    IcySixel,
 }
 
 impl Printer for PrinterType {
@@ -70,6 +82,8 @@ impl Printer for PrinterType {
             PrinterType::iTerm => iTermPrinter.print(stdout, img, config),
             #[cfg(feature = "sixel")]
             PrinterType::Sixel => SixelPrinter.print(stdout, img, config),
+            #[cfg(feature = "icy_sixel")]
+            PrinterType::IcySixel => IcySixelPrinter.print(stdout, img, config),
         }
     }
 
@@ -86,6 +100,8 @@ impl Printer for PrinterType {
             PrinterType::iTerm => iTermPrinter.print_from_file(stdout, filename, config),
             #[cfg(feature = "sixel")]
             PrinterType::Sixel => SixelPrinter.print_from_file(stdout, filename, config),
+            #[cfg(feature = "icy_sixel")]
+            PrinterType::IcySixel => IcySixelPrinter.print_from_file(stdout, filename, config),
         }
     }
 }

--- a/src/printer/sixel.rs
+++ b/src/printer/sixel.rs
@@ -1,23 +1,12 @@
 use crate::error::ViuResult;
 use crate::printer::{adjust_offset, find_best_fit, Printer};
 use crate::Config;
-use console::{Key, Term};
 use image::{imageops::FilterType, DynamicImage, GenericImageView};
-use lazy_static::lazy_static;
 use sixel_rs::encoder::{Encoder, QuickFrameBuilder};
 use sixel_rs::optflags::EncodePolicy;
 use std::io::Write;
 
 pub struct SixelPrinter;
-
-lazy_static! {
-    static ref SIXEL_SUPPORT: bool = check_sixel_support();
-}
-
-/// Returns the terminal's support for Sixel.
-pub fn is_sixel_supported() -> bool {
-    *SIXEL_SUPPORT
-}
 
 impl Printer for SixelPrinter {
     fn print(
@@ -53,45 +42,4 @@ impl Printer for SixelPrinter {
 
         Ok((w, h))
     }
-}
-
-// Check if Sixel is within the terminal's attributes
-// see https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h2-Sixel-Graphics
-// and https://vt100.net/docs/vt510-rm/DA1.html
-fn check_device_attrs() -> ViuResult<bool> {
-    let mut term = Term::stdout();
-
-    write!(&mut term, "\x1b[c")?;
-    term.flush()?;
-
-    let mut response = String::new();
-
-    while let Ok(key) = term.read_key() {
-        if let Key::Char(c) = key {
-            response.push(c);
-            if c == 'c' {
-                break;
-            }
-        }
-    }
-
-    Ok(response.contains(";4;") || response.contains(";4c"))
-}
-
-// Check if Sixel protocol can be used
-fn check_sixel_support() -> bool {
-    if let Ok(term) = std::env::var("TERM") {
-        match term.as_str() {
-            "mlterm" | "yaft-256color" | "foot" | "foot-extra" | "eat-truecolor" => return true,
-            "st-256color" | "xterm" | "xterm-256color" => {
-                return check_device_attrs().unwrap_or(false)
-            }
-            _ => {
-                if let Ok(term_program) = std::env::var("TERM_PROGRAM") {
-                    return term_program == "MacTerm";
-                }
-            }
-        }
-    }
-    false
 }

--- a/src/printer/sixel_util.rs
+++ b/src/printer/sixel_util.rs
@@ -1,0 +1,61 @@
+use console::{Key, Term};
+use lazy_static::lazy_static;
+use std::io::Write;
+use crate::ViuResult;
+
+lazy_static! {
+    static ref SIXEL_SUPPORT: bool = check_sixel_support();
+}
+
+/// Returns the terminal's support for Sixel.
+pub fn is_sixel_supported() -> bool {
+    *SIXEL_SUPPORT
+}
+
+// Check if Sixel is within the terminal's attributes
+// see https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h2-Sixel-Graphics
+// and https://vt100.net/docs/vt510-rm/DA1.html
+fn check_device_attrs() -> ViuResult<bool> {
+    let mut term = Term::stdout();
+
+    write!(&mut term, "\x1b[c")?;
+    term.flush()?;
+
+    let mut response = String::new();
+
+    while let Ok(key) = term.read_key() {
+        if let Key::Char(c) = key {
+            response.push(c);
+            if c == 'c' {
+                break;
+            }
+        }
+    }
+
+    Ok(response.contains(";4;") || response.contains(";4c"))
+}
+
+// Check if Sixel protocol can be used
+fn check_sixel_support() -> bool {
+    if let Ok(term) = std::env::var("TERM") {
+        match term.as_str() {
+            "mlterm" | "yaft-256color" | "foot" | "foot-extra" | "eat-truecolor" => return true,
+            "st-256color" | "xterm" | "xterm-256color" => {
+                return check_device_attrs().unwrap_or(false)
+            }
+            _ => {
+                if let Ok(term_program) = std::env::var("TERM_PROGRAM") {
+                    return term_program == "MacTerm";
+                }
+            }
+        }
+    }
+
+    // Windows terminal.
+    #[cfg(feature = "icy_sixel")]
+    if let Ok(_guid) = std::env::var("WT_SESSION") {
+        return true;
+    }
+
+    false
+}


### PR DESCRIPTION
This adds experimental support for [icy_sixel](https://github.com/mkrueger/icy_sixel) as an alternative for libsixel, guarded by the `icy_sixel` feature flag.

Why `icy_sixel`?
- Pure rust code is much nicer to build using cargo.
- `sixel-sys` has issues to build in Windows and seems to be a bit tricky to fix (Windows Terminal Preview supports Sixel).

Other notes:
- I just used "auto" for all the parameters to `icy_sixel` and I haven't tested it a ton. So the feature flag should definitely be marked as experimental. It *seems* to run fine though :-).
- I moved the code for checking terminal support to a separate `sixel_util` module, that is compiled, if either `sixel` or `icy_sixel` is enabled.
- I've extended `check_sixel_support()`, to check for the `WT_SESSION` environment variable, which is set by Windows Terminal (may not be the best way of detecting it, but  seemed to be the simplest change). The code will then just assume `true`, because running `check_device_attrs()` was giving me trouble. As a precaution, the if-branch is only compiled in, if `icy_sixel` is enabled.
- If both `sixel` and `icy_sixel` are enabled, the code will use `icy_sixel`. This seemed reasonable, as it is the more specific feature flag.

Extending `viu` to also support the `icy_sixel` feature flag would be appreciated (should be a trivial pass-through).