### PR TITLE
add rio terminal support to sixel and iterm2 protocol

### DIFF
--- a/src/printer/iterm.rs
+++ b/src/printer/iterm.rs
@@ -92,12 +92,12 @@ fn print_buffer(
 // Check if the iTerm protocol can be used
 fn check_iterm_support() -> bool {
     if let Ok(term) = std::env::var("TERM_PROGRAM") {
-        if term.contains("iTerm") || term.contains("WezTerm") || term.contains("mintty") {
+        if term.contains("iTerm") || term.contains("WezTerm") || term.contains("mintty") || term.contains("rio") {
             return true;
         }
     }
     if let Ok(lc_term) = std::env::var("LC_TERMINAL") {
-        if lc_term.contains("iTerm") || lc_term.contains("WezTerm") || lc_term.contains("mintty") {
+        if lc_term.contains("iTerm") || lc_term.contains("WezTerm") || lc_term.contains("mintty") || lc_term.contains("rio") {
             return true;
         }
     }

--- a/src/printer/sixel.rs
+++ b/src/printer/sixel.rs
@@ -82,7 +82,7 @@ fn check_device_attrs() -> ViuResult<bool> {
 fn check_sixel_support() -> bool {
     if let Ok(term) = std::env::var("TERM") {
         match term.as_str() {
-            "mlterm" | "yaft-256color" | "foot" | "foot-extra" | "eat-truecolor" => return true,
+            "mlterm" | "yaft-256color" | "foot" | "foot-extra" | "eat-truecolor" | "rio" => return true,
             "st-256color" | "xterm" | "xterm-256color" => {
                 return check_device_attrs().unwrap_or(false)
             }


### PR DESCRIPTION
Thank you for the awesome project, added the capability of sixel and iterm2 for Rio terminal

<img width="1268" alt="Screenshot 2024-12-18 at 22 39 57" src="https://github.com/user-attachments/assets/1976f572-999a-4727-8738-5d9480418148" />
