### PR TITLE
Add support for Warp Terminal

### DIFF
--- a/src/printer/iterm.rs
+++ b/src/printer/iterm.rs
@@ -96,6 +96,7 @@ fn check_iterm_support() -> bool {
             || term.contains("WezTerm")
             || term.contains("mintty")
             || term.contains("rio")
+            || term.contains("WarpTerminal")
         {
             return true;
         }


### PR DESCRIPTION
Warp terminal supports iTerm protocol. Addresses #71 
Here's a screenshot of viu working with iterm in the Warp terminal.
<img width="1084" alt="Screenshot 2025-05-09 at 12 51 48 AM" src="https://github.com/user-attachments/assets/cf6523b7-b009-4352-a679-511b39e571b0" />
