### PR TITLE
Update crossterm & sixel-rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## 0.9.2
 - Use iterm and sixel in more terminals
+- Bump `crossterm` and `sixel-rs` dependencies
 
 ## 0.9.1
 - Add docs.rs metadata

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,14 +17,14 @@ rust-version = "1.80"
 ansi_colours = "1"
 base64 = "0.22"
 console = { version = "0.15", default-features = false }
-crossterm = { version = "0.28", default-features = false }
+crossterm = { version = "0.29", default-features = false }
 image = { version = "0.25", default-features = false, features = ["png"] }
 tempfile = "3"
 termcolor = "1"
 sixel-rs = { version = "0.3", optional = true}
 
 [target.'cfg(windows)'.dependencies]
-crossterm = { version = "0.28", default-features = false, features = ["windows"]}
+crossterm = { version = "0.29", default-features = false, features = ["windows"]}
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ crossterm = { version = "0.29", default-features = false }
 image = { version = "0.25", default-features = false, features = ["png"] }
 tempfile = "3"
 termcolor = "1"
-sixel-rs = { version = "0.3", optional = true}
+sixel-rs = { version = "0.5", optional = true}
 
 [target.'cfg(windows)'.dependencies]
 crossterm = { version = "0.29", default-features = false, features = ["windows"]}


### PR DESCRIPTION
This PR updates the dependencies `crossterm` and `sixel-rs` to their current latest version.

Note that the CI will fail until #76 is included in this branch.