### PR TITLE
refactor: drop lazy_static in favor of std::sync::LazyLock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## next
+- remove `lazy_static` dependency in favor of `std::sync::LazyLock`
+- MSRV is now 1.80
+
 ## 0.9.1
 - Add docs.rs metadata
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT"
 categories = ["command-line-interface"]
 keywords = ["terminal", "image"]
 exclude = [".github"]
+rust-version = "1.80"
 
 [dependencies]
 ansi_colours = "1"
@@ -18,7 +19,6 @@ base64 = "0.22"
 console = { version = "0.15", default-features = false }
 crossterm = { version = "0.28", default-features = false }
 image = { version = "0.25", default-features = false, features = ["png"] }
-lazy_static = "1.5"
 tempfile = "3"
 termcolor = "1"
 sixel-rs = { version = "0.3", optional = true}

--- a/src/printer/iterm.rs
+++ b/src/printer/iterm.rs
@@ -3,8 +3,8 @@ use crate::printer::{adjust_offset, find_best_fit, Printer};
 use crate::Config;
 use base64::{engine::general_purpose, Engine};
 use image::{DynamicImage, GenericImageView, ImageEncoder};
-use lazy_static::lazy_static;
 use std::io::Write;
+use std::sync::LazyLock;
 
 #[cfg(feature = "print-file")]
 use std::{
@@ -15,9 +15,7 @@ use std::{
 #[allow(non_camel_case_types)]
 pub struct iTermPrinter;
 
-lazy_static! {
-    static ref ITERM_SUPPORT: bool = check_iterm_support();
-}
+static ITERM_SUPPORT: LazyLock<bool> = LazyLock::new(check_iterm_support);
 
 /// Returns the terminal's support for the iTerm graphics protocol.
 pub fn is_iterm_supported() -> bool {

--- a/src/printer/kitty.rs
+++ b/src/printer/kitty.rs
@@ -3,8 +3,8 @@ use crate::printer::{adjust_offset, find_best_fit, Printer};
 use crate::Config;
 use base64::{engine::general_purpose, Engine};
 use console::{Key, Term};
-use std::io::Write;
 use std::io::Error;
+use std::io::Write;
 use std::sync::LazyLock;
 use tempfile::NamedTempFile;
 

--- a/src/printer/kitty.rs
+++ b/src/printer/kitty.rs
@@ -3,17 +3,15 @@ use crate::printer::{adjust_offset, find_best_fit, Printer};
 use crate::Config;
 use base64::{engine::general_purpose, Engine};
 use console::{Key, Term};
-use lazy_static::lazy_static;
 use std::io::Write;
 use std::io::{Error, ErrorKind};
+use std::sync::LazyLock;
 use tempfile::NamedTempFile;
 
 pub struct KittyPrinter;
 
 const TEMP_FILE_PREFIX: &str = ".tty-graphics-protocol.viuer.";
-lazy_static! {
-    static ref KITTY_SUPPORT: KittySupport = check_kitty_support();
-}
+static KITTY_SUPPORT: LazyLock<KittySupport> = LazyLock::new(check_kitty_support);
 
 /// Returns the terminal's support for the Kitty graphics protocol.
 pub fn get_kitty_support() -> KittySupport {

--- a/src/printer/sixel.rs
+++ b/src/printer/sixel.rs
@@ -3,16 +3,14 @@ use crate::printer::{adjust_offset, find_best_fit, Printer};
 use crate::Config;
 use console::{Key, Term};
 use image::{imageops::FilterType, DynamicImage, GenericImageView};
-use lazy_static::lazy_static;
 use sixel_rs::encoder::{Encoder, QuickFrameBuilder};
 use sixel_rs::optflags::EncodePolicy;
 use std::io::Write;
+use std::sync::LazyLock;
 
 pub struct SixelPrinter;
 
-lazy_static! {
-    static ref SIXEL_SUPPORT: bool = check_sixel_support();
-}
+static SIXEL_SUPPORT: LazyLock<bool> = LazyLock::new(check_sixel_support);
 
 /// Returns the terminal's support for Sixel.
 pub fn is_sixel_supported() -> bool {


### PR DESCRIPTION
This PR drops the dependency on `lazy_static` in favor of `std::sync::LazyLock`.
This means to increase the MSRV which previously was ~1.68(according to lib.rs for 0.9.1) to 1.80.