### PR TITLE
fix(sixel): exit loop on "Unknown" keys

### DIFF
--- a/src/printer/sixel.rs
+++ b/src/printer/sixel.rs
@@ -65,6 +65,11 @@ fn check_device_attrs() -> ViuResult<bool> {
     let mut response = String::new();
 
     while let Ok(key) = term.read_key() {
+        // exit on first "Unknown" key as we know that this is not a proper response anymore
+        if key == Key::Unknown {
+            break;
+        }
+
         if let Key::Char(c) = key {
             response.push(c);
             if c == 'c' {


### PR DESCRIPTION
This fixes running tests with feature "sixel" enabled on terminal Konsole. The problematic test is `lib.rs@14`(doctest).
I got this tracked down due to having encountered a similar problem when i did kitty #79, specifically, read https://github.com/atanunq/viuer/pull/79#issuecomment-2994315635.