### PR TITLE
 fix explicit TERM for check sixel support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## next
 - remove `lazy_static` dependency in favor of `std::sync::LazyLock`
 - MSRV is now 1.80
+- Use sixel if found in device attributes instead of static TERM list
 
 ## 0.9.2
 - Use iterm and sixel in more terminals

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
 #![deny(missing_docs)]
+// Temporary until https://github.com/rust-lang/rust-clippy/issues/15151 is rolled out
+#![allow(clippy::uninlined_format_args)]
 
 //! Library to display images in the terminal.
 //!

--- a/src/printer/sixel.rs
+++ b/src/printer/sixel.rs
@@ -85,18 +85,18 @@ fn check_device_attrs() -> ViuResult<bool> {
 fn check_sixel_support() -> bool {
     if let Ok(term) = std::env::var("TERM") {
         match term.as_str() {
-            "mlterm" | "yaft-256color" | "foot" | "foot-extra" | "eat-truecolor" | "rio" => {
-                return true
-            }
-            "st-256color" | "xterm" | "xterm-256color" => {
-                return check_device_attrs().unwrap_or(false)
+            "yaft-256color" | "eat-truecolor" => {
+                return true;
             }
             _ => {
                 if let Ok(term_program) = std::env::var("TERM_PROGRAM") {
-                    return term_program == "MacTerm";
+                    if term_program == "MacTerm" {
+                        return true;
+                    }
                 }
             }
         }
+        return check_device_attrs().unwrap_or(false);
     }
     false
 }


### PR DESCRIPTION
The PR adds alacritty to the supported sixel termnals.
The purpose is to support the [alacritty fork that supports sixel](https://github.com/ayosec/alacritty).
Fixes #73 