### PR TITLE
feat(config): Allow to force using ITerm for VSCode

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -31,6 +31,11 @@ pub struct Config {
     pub use_kitty: bool,
     /// Use iTerm protocol if the terminal supports it. Defaults to true.
     pub use_iterm: bool,
+    /// Use Iterm to display images in VScode. Defaults to false, and will display using lower half blocks instead.
+    /// 
+    /// While VSCode supports the iTerm protocol, it is currently opt-in in the app's settings. 
+    /// If an image is displayed using ITerm and VScode isn't configuarted to display it, nothing will print, so use carefully.
+    pub allow_vscode: bool,
     /// Use Sixel protocol if the terminal supports it. Defaults to true.
     #[cfg(feature = "sixel")]
     pub use_sixel: bool,
@@ -50,6 +55,7 @@ impl std::default::Default for Config {
             truecolor: utils::truecolor_available(),
             use_kitty: true,
             use_iterm: true,
+            allow_vscode: false,
             #[cfg(feature = "sixel")]
             use_sixel: true,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,8 @@ pub use utils::terminal_size;
 #[cfg(feature = "sixel")]
 pub use printer::is_sixel_supported;
 
+use crate::utils::is_term_vscode;
+
 /// Default printing method. Uses either iTerm or Kitty graphics protocol, if supported,
 /// and half blocks otherwise.
 ///
@@ -146,7 +148,7 @@ fn choose_printer(config: &Config) -> PrinterType {
         return PrinterType::Sixel;
     }
 
-    if config.use_iterm && is_iterm_supported() {
+    if config.use_iterm && (is_iterm_supported() || (config.allow_vscode && is_term_vscode())) {
         PrinterType::iTerm
     } else if config.use_kitty && get_kitty_support() != KittySupport::None {
         PrinterType::Kitty

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -10,6 +10,10 @@ pub fn truecolor_available() -> bool {
     }
 }
 
+pub fn is_term_vscode() -> bool {
+    std::env::var("TERM_PROGRAM").is_ok_and(|term| term == "vscode")
+}
+
 /// Try to get the terminal size. If unsuccessful, fallback to a default (80x24). Uses [crossterm::terminal::size].
 #[cfg(not(test))]
 pub fn terminal_size() -> (u16, u16) {


### PR DESCRIPTION
VScode has an opt-in option to display iTerm image in the terminal.

This PR add a option in the configuration to force vuier to use iTerm if in a vscode environement

By default this option is false, as half blocks are always displayed, whereas iTerm will display nothing if the option is turned off